### PR TITLE
feat: add gaia storage for storing transaction ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@stacks/common": "^5.0.0",
         "@stacks/connect": "^7.0.0",
         "@stacks/network": "^5.0.0",
+        "@stacks/storage": "^5.0.2",
         "@stacks/transactions": "^5.0.2",
         "axios": "^1.1.3",
         "jsontokens": "^4.0.1"
@@ -186,6 +187,19 @@
         "jsontokens": "^4.0.1",
         "schema-inspector": "2.0.1",
         "zone-file": "^2.0.0-beta.3"
+      }
+    },
+    "node_modules/@stacks/storage": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@stacks/storage/-/storage-5.0.2.tgz",
+      "integrity": "sha512-X1sM9Fu1tVjhsfjv1tmPi2r6aBeizECwm6Y19boRk7coT3MzDp6T6AF2RtuW8TBPJhpet9bMOTtVSvnmaiPegA==",
+      "dependencies": {
+        "@stacks/auth": "^5.0.2",
+        "@stacks/common": "^5.0.0",
+        "@stacks/encryption": "^5.0.0",
+        "@stacks/network": "^5.0.0",
+        "base64-js": "^1.5.1",
+        "jsontokens": "^4.0.1"
       }
     },
     "node_modules/@stacks/transactions": {
@@ -1133,6 +1147,19 @@
         "jsontokens": "^4.0.1",
         "schema-inspector": "2.0.1",
         "zone-file": "^2.0.0-beta.3"
+      }
+    },
+    "@stacks/storage": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@stacks/storage/-/storage-5.0.2.tgz",
+      "integrity": "sha512-X1sM9Fu1tVjhsfjv1tmPi2r6aBeizECwm6Y19boRk7coT3MzDp6T6AF2RtuW8TBPJhpet9bMOTtVSvnmaiPegA==",
+      "requires": {
+        "@stacks/auth": "^5.0.2",
+        "@stacks/common": "^5.0.0",
+        "@stacks/encryption": "^5.0.0",
+        "@stacks/network": "^5.0.0",
+        "base64-js": "^1.5.1",
+        "jsontokens": "^4.0.1"
       }
     },
     "@stacks/transactions": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@stacks/common": "^5.0.0",
     "@stacks/connect": "^7.0.0",
     "@stacks/network": "^5.0.0",
+    "@stacks/storage": "^5.0.2",
     "@stacks/transactions": "^5.0.2",
     "axios": "^1.1.3",
     "jsontokens": "^4.0.1"

--- a/src/components/Dashboard.svelte
+++ b/src/components/Dashboard.svelte
@@ -5,6 +5,7 @@
   import Register from "./Register.svelte";
   import Transfer from "./Transfer.svelte";
   import Preorder from "./Preorder.svelte";
+  import Transactions from "./Transactions.svelte";
 
   let authResponse;
   let publicKey;
@@ -57,6 +58,7 @@
     <Preorder />
     <Register />
     <Transfer />
+    <Transactions />
   {:else}
     <button on:click={authenticate}> Connect Wallet! </button>
   {/if}

--- a/src/components/Preorder.svelte
+++ b/src/components/Preorder.svelte
@@ -5,15 +5,11 @@
     bufferCV,
     uintCV,
     createSTXPostCondition,
-    parseAssetInfoString,
-    AddressVersion,
-    createStacksPublicKey,
     FungibleConditionCode,
     PostConditionMode,
   } from "@stacks/transactions";
   import { utf8ToBytes } from "@stacks/common";
-  import { SECP256K1Client } from "jsontokens";
-  import { makeContractCall } from "../makeContractCall.js";
+  import { makeContractCall } from "../helpers/makeContractCall.js";
 
   // preorder form field values
   let preorderBnsName;

--- a/src/components/Register.svelte
+++ b/src/components/Register.svelte
@@ -1,24 +1,12 @@
 <script>
-  import { openContractCall } from "@stacks/connect";
-  import { userSession } from "../createUserSession";
-  import { StacksTestnet } from "@stacks/network";
   import {
     hash160,
     bufferCV,
-    uintCV,
-    createSTXPostCondition,
-    parseAssetInfoString,
-    AddressVersion,
-    createStacksPublicKey,
-    FungibleConditionCode,
-    publicKeyToAddress,
     bufferCVFromString,
-    NonFungibleConditionCode,
     PostConditionMode,
   } from "@stacks/transactions";
   import { utf8ToBytes } from "@stacks/common";
-  import { SECP256K1Client } from "jsontokens";
-  import { makeContractCall } from "../makeContractCall.js";
+  import { makeContractCall } from "../helpers/makeContractCall.js";
 
   // register form fields
   let registerBnsName;

--- a/src/components/StxTransfer.svelte
+++ b/src/components/StxTransfer.svelte
@@ -1,24 +1,27 @@
-<script>  
-    import { openSTXTransfer } from '@stacks/connect';
+<script>
+  import { openSTXTransfer } from "@stacks/connect";
+  import { saveUpdatedFile } from "../helpers/saveUpdatedFile";
 
-    let address;
-    let amount;
-    const sendToken = async () => {
-        const options = {
-            recipient: address,
-            amount: amount
-        };
-        await openSTXTransfer(options);
-        address = '';
-        amount = '';
-    }
+  let address;
+  let amount;
+  const sendToken = async () => {
+    const options = {
+      recipient: address,
+      amount: amount,
+      onFinish: async (data) => saveUpdatedFile("stx-transfer", data.txId),
+    };
+    await openSTXTransfer(options);
+
+    address = "";
+    amount = "";
+  };
 </script>
 
 <main>
-    <form on:submit|preventDefault={sendToken}>
-        <input type="text" placeholder="Address" bind:value={address}>
-        <input type="number" placeholder="Amount" bind:value={amount}>
-        <button type="submit">Send!</button>
-    </form>
-    <br><br>
+  <form on:submit|preventDefault={sendToken}>
+    <input type="text" placeholder="Address" bind:value={address} />
+    <input type="number" placeholder="Amount" bind:value={amount} />
+    <button type="submit">Send!</button>
+  </form>
+  <br /><br />
 </main>

--- a/src/components/Transactions.svelte
+++ b/src/components/Transactions.svelte
@@ -1,0 +1,14 @@
+<script>
+  import { fetchTransactions } from "../helpers/saveUpdatedFile";
+</script>
+
+<main>
+  <h2>Transactions</h2>
+  {#await fetchTransactions() then transactions}
+    <ol>
+      {#each transactions as tx}
+        <li>{tx.type} - {tx.txid}</li>
+      {/each}
+    </ol>
+  {/await}
+</main>

--- a/src/components/Transfer.svelte
+++ b/src/components/Transfer.svelte
@@ -13,7 +13,7 @@
     PostConditionMode,
   } from "@stacks/transactions";
   import { utf8ToBytes } from "@stacks/common";
-  import { makeContractCall } from "../makeContractCall.js";
+  import { makeContractCall } from "../helpers/makeContractCall.js";
 
   //transfer form field values
   let transferBnsName;

--- a/src/createUserSession.js
+++ b/src/createUserSession.js
@@ -1,5 +1,8 @@
 import { UserSession, AppConfig } from "@stacks/connect";
+import { Storage } from "@stacks/storage";
 
 const appConfig = new AppConfig(["store_write", "publish_data"]);
 
 export const userSession = new UserSession({ appConfig });
+
+export const storage = new Storage({ userSession });

--- a/src/helpers/makeContractCall.js
+++ b/src/helpers/makeContractCall.js
@@ -1,5 +1,6 @@
 import { openContractCall } from "@stacks/connect";
 import { StacksTestnet } from "@stacks/network";
+import { saveUpdatedFile } from "./saveUpdatedFile";
 
 export const makeContractCall = async (
   functionName,
@@ -16,14 +17,8 @@ export const makeContractCall = async (
     functionArgs,
     postConditionMode,
     postConditions,
-    onFinish: (data) => {
-      console.log("onFinish:", data);
-      window
-        .open(
-          `https://explorer.stacks.co/txid/${data.txId}?chain=testnet`,
-          "_blank"
-        )
-        .focus();
+    onFinish: async (data) => {
+      saveUpdatedFile(functionName, data.txId);
     },
     onCancel: () => {
       console.log("onCancel:", "Transaction was canceled");

--- a/src/helpers/saveTransaction.js
+++ b/src/helpers/saveTransaction.js
@@ -1,0 +1,11 @@
+import { storage } from "../createUserSession.js";
+
+export const saveTransaction = async (txType, txid) => {
+  // save the txid and tx type
+  const txData = JSON.stringify({
+    txType,
+    txid,
+  });
+  const fileUrl = await storage.putFile("transaction_data.json", txData);
+  return fileUrl;
+};

--- a/src/helpers/saveUpdatedFile.js
+++ b/src/helpers/saveUpdatedFile.js
@@ -1,0 +1,22 @@
+import { storage } from "../createUserSession";
+
+const fetchTransactions = async () => {
+  try {
+    let transactionData = await storage.getFile("transaction_data.json");
+    transactionData = JSON.parse(transactionData);
+    return transactionData;
+  } catch (e) {}
+};
+
+export const saveUpdatedFile = async (transactionType, txid) => {
+  const transactionData = await fetchTransactions(); // an array
+  const txObject = {
+    txid,
+    type: transactionType,
+  };
+  const updatedArray = [...(transactionData || []), txObject];
+  const fileUrl = await storage.putFile(
+    "transaction_data.json",
+    JSON.stringify(updatedArray)
+  );
+};


### PR DESCRIPTION
## Overivew

1. This PR contains GAIA support for storing transaction ids and types.